### PR TITLE
[traxter_ign_gazebo]: removed unnecessary line from CMakeLists.txt

### DIFF
--- a/traxter_ign_gazebo/CMakeLists.txt
+++ b/traxter_ign_gazebo/CMakeLists.txt
@@ -28,7 +28,6 @@ install(
   DIRECTORY
     launch
     worlds
-    models
   DESTINATION
     share/${PROJECT_NAME}/
 )


### PR DESCRIPTION
Cannot compile without this change. An artifact of previous code base was left on CMakeLists.txt of traxter_ign_gazebo package.